### PR TITLE
remove `markFormatter`s

### DIFF
--- a/books/weihnachtslieder/der_heiland_ist_geboren_voices.ly
+++ b/books/weihnachtslieder/der_heiland_ist_geboren_voices.ly
@@ -55,7 +55,6 @@ DHI_Score = \score {
     \override Score.BarNumber.break-visibility = #end-of-line-invisible %%every bar is numbered.!!
     %% remove previous line to get barnumbers only at beginning of system.
     #(set-accidental-style 'modern-cautionary)
-    \set Score.markFormatter = #format-mark-box-letters %%boxed rehearsal-marks
     \override Score.TimeSignature.style = #'() %%makes timesigs always numerical
     %% remove previous line to get cut-time/alla breve or common time
     \set Score.pedalSustainStyle = #'mixed

--- a/books/weihnachtslieder/jingle_bells_voices.ly
+++ b/books/weihnachtslieder/jingle_bells_voices.ly
@@ -70,7 +70,6 @@ JIB_Score = \score {
     \override Score.BarNumber.break-visibility = #end-of-line-invisible %%every bar is numbered.!!!
     %% remove previous line to get barnumbers only at beginning of system.
     #(set-accidental-style 'modern-cautionary)
-    \set Score.markFormatter = #format-mark-box-letters %%boxed rehearsal-marks
     \override Score.TimeSignature.style = #'() %%makes timesigs always numerical
     %% remove previous line to get cut-time/alla breve or common time
     \set Score.pedalSustainStyle = #'mixed

--- a/books/weihnachtslieder/joseph_lieber_joseph_mein_voices.ly
+++ b/books/weihnachtslieder/joseph_lieber_joseph_mein_voices.ly
@@ -45,7 +45,6 @@ JLJ_Score = {
     \override Score.BarNumber.break-visibility = #end-of-line-invisible %%every bar is numbered.!!!
     %% remove previous line to get barnumbers only at beginning of system.
     #(set-accidental-style 'modern-cautionary)
-    \set Score.markFormatter = #format-mark-box-letters %%boxed rehearsal-marks
     \override Score.TimeSignature.style = #'() %%makes timesigs always numerical
     %% remove previous line to get cut-time/alla breve or common time
     \set Score.pedalSustainStyle = #'mixed

--- a/books/weihnachtslieder/we_wish_you_merry_christmas_voices.ly
+++ b/books/weihnachtslieder/we_wish_you_merry_christmas_voices.ly
@@ -67,7 +67,6 @@ WWY_Score = \score {
     \set Score.skipBars = ##t
     \override Score.BarNumber.break-visibility = #end-of-line-invisible
     #(set-accidental-style 'modern-cautionary)
-    \set Score.markFormatter = #format-mark-box-letters
     \override Score.TimeSignature.style = #'()
     \set Score.pedalSustainStyle = #'mixed
     \override Score.TrillSpanner.bound-details.right.padding = #-2

--- a/books/weihnachtslieder/zu_bethlehem_geboren_voices.ly
+++ b/books/weihnachtslieder/zu_bethlehem_geboren_voices.ly
@@ -41,7 +41,6 @@ ZBG_Score = \score {
     \override Score.BarNumber.break-visibility = ##f %%every bar is numbered.!!!
     %% remove previous line to get barnumbers only at beginning of system.
     #(set-accidental-style 'modern-cautionary)
-    \set Score.markFormatter = #format-mark-box-letters %%boxed rehearsal-marks
     \override Score.TimeSignature.style = #'() %%makes timesigs always numerical
     %% remove previous line to get cut-time/alla breve or common time
     \set Score.pedalSustainStyle = #'mixed


### PR DESCRIPTION
fixes
warning: cannot find property type-check for `markFormatter' (translation-type?).  perhaps a typing error?
